### PR TITLE
feat: reduce prominence of skip button

### DIFF
--- a/app/components/Episode/WatchForm.tsx
+++ b/app/components/Episode/WatchForm.tsx
@@ -107,9 +107,14 @@ export const Component: React.FC<Props> = ({
             <Button.Component type="submit" name="_action" value="watch">
               {fetcher.state === "idle" ? "視聴した" : "送信中"}
             </Button.Component>
-            <Button.Component type="submit" name="_action" value="skip">
+            <button
+              type="submit"
+              name="_action"
+              value="skip"
+              className="self-end text-text-weak text-sm"
+            >
               スキップ
-            </Button.Component>
+            </button>
           </fetcher.Form>
         )}
       </div>


### PR DESCRIPTION
## Summary
- visually de-emphasize skip option on episode watch form

## Testing
- `npm test` *(fails: SECRET environment variable is required; date test assertion failure)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688f7a3ea4bc832f86d8d11e4b0f4136